### PR TITLE
Fix unnecessary calls to /api/mercury/v2/users/me

### DIFF
--- a/lib/omniauth/aid/version.rb
+++ b/lib/omniauth/aid/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Aid
-      VERSION = "2.0.4"
+      VERSION = "2.0.5"
   end
 end

--- a/lib/omniauth/strategies/aid.rb
+++ b/lib/omniauth/strategies/aid.rb
@@ -36,8 +36,10 @@ module OmniAuth
       end
 
       def raw_info
-        response_body = access_token.get('/api/mercury/v2/users/me').body
-        @raw_info ||= JSON.parse(response_body) || {}
+        @raw_info ||= begin
+          response_body = access_token.get('/api/mercury/v2/users/me').body
+          JSON.parse(response_body) || {}
+        end
       end
     end
   end


### PR DESCRIPTION
There are seven or eight unnecessary calls to ``/api/mercury/v2/users/me`` being made each time someone is logged in. This fix will make sure it only gets called once.